### PR TITLE
fix typo problems in data modules

### DIFF
--- a/data_provider/stage2_chebi_dm.py
+++ b/data_provider/stage2_chebi_dm.py
@@ -91,7 +91,7 @@ class TrainCollater:
         ## concate text and prompt
 
         # texts = [escape_custom_split_sequence(prompt + text) for prompt, text in zip(smiles_prompt, texts)]
-        self.tokenizer.paddding_side = 'left'
+        self.tokenizer.padding_side = 'left'
         smiles_prompt_tokens = self.tokenizer(text=smiles_prompt, 
                                               truncation=False,
                                               padding='longest',
@@ -103,7 +103,7 @@ class TrainCollater:
         smiles_prompt_tokens['is_mol_token'] = is_mol_token
         # print(smiles_prompt_tokens.input_ids, self.mol_token_id)
         # print(is_mol_token)
-        self.tokenizer.paddding_side = 'right'
+        self.tokenizer.padding_side = 'right'
         text_tokens = self.tokenizer(text=texts,
                                      truncation=True,
                                      padding='longest',
@@ -129,7 +129,7 @@ class InferenceCollater:
         graphs = self.collater(graphs)
         smiles_prompt = [smiles_handler(p, self.mol_ph, self.is_gal)[0] for p in smiles_prompt]
         ## deal with prompt
-        self.tokenizer.paddding_side = 'left'
+        self.tokenizer.padding_side = 'left'
         smiles_prompt_tokens = self.tokenizer(smiles_prompt, 
                                        return_tensors='pt', 
                                     #    max_length=self.text_max_len, 

--- a/data_provider/stage2_dm.py
+++ b/data_provider/stage2_dm.py
@@ -82,7 +82,7 @@ class TrainCollater:
         ## deal with prompt
         smiles_prompt = [smiles_handler(p, self.mol_ph, self.is_gal)[0] for p in smiles_prompt]
 
-        self.tokenizer.paddding_side = 'left'
+        self.tokenizer.padding_side = 'left'
         smiles_prompt_tokens = self.tokenizer(text=smiles_prompt, 
                                               truncation=False,
                                               padding='longest',
@@ -93,7 +93,7 @@ class TrainCollater:
         is_mol_token = smiles_prompt_tokens.input_ids == self.mol_token_id
         smiles_prompt_tokens['is_mol_token'] = is_mol_token
 
-        self.tokenizer.paddding_side = 'right'
+        self.tokenizer.padding_side = 'right'
         text_tokens = self.tokenizer(text=texts,
                                      truncation=True,
                                      padding='longest',
@@ -119,7 +119,7 @@ class InferenceCollater:
         smiles_prompt = [smiles_handler(p, self.mol_ph, self.is_gal)[0] for p in smiles_prompt]
 
         ## deal with prompt
-        self.tokenizer.paddding_side = 'left'
+        self.tokenizer.padding_side = 'left'
         smiles_prompt_tokens = self.tokenizer(smiles_prompt, 
                                               return_tensors='pt', 
                                               add_special_tokens=True,


### PR DESCRIPTION
The `padding_side` of tokenizers are misspelled as `paddding_side`. This pr replace all `paddding_side` in this repo with `padding_side`. 